### PR TITLE
Updated to require MacOS 10.9 at build

### DIFF
--- a/aquamacs/build/build.sh
+++ b/aquamacs/build/build.sh
@@ -48,8 +48,8 @@ echo "Compiler flags: $FLAGS"
 # do not use MacPorts / fink libraries
 # do not use binaries either (e.g., gnutls would be recognized)
 
-# We will run only on 10.6 and later.
-MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-"10.6"}
+# We will run only on 10.9 and later.
+MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-"10.9"}
 export MACOSX_DEPLOYMENT_TARGET
 
 FINALMESSAGE=""
@@ -59,7 +59,7 @@ then
 # we're going to choose the oldest SDK we have (starting with 10.9)
 # this should guarantee backwards compatibility up to that SDK version.
 # for current Aquamacs, this will typically be 10.9
-for VERS in 10.6 10.7 10.8 10.9 10.10 10.11 10.12 10.13 10.14; do
+for VERS in 10.9 10.10 10.11 10.12 10.13 10.14; do
     SDK="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${VERS}.sdk"
     if [ -d "$SDK" ]; then
         FINALMESSAGE="This build will be compatible with OS X $VERS onwards."

--- a/configure.ac
+++ b/configure.ac
@@ -1864,23 +1864,23 @@ Either fix this, or re-configure with the option '--without-ns'.])])
 
   macfont_file=""
   if test "${NS_IMPL_COCOA}" = "yes"; then
-    AC_MSG_CHECKING([for Mac OS X 10.6 or newer])
+    AC_MSG_CHECKING([for Mac OS X 10.9 or newer])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <AppKit/AppKit.h>],
                                      [
 #ifdef MAC_OS_X_VERSION_MAX_ALLOWED
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
  ; /* OK */
 #else
- error "Mac OS X 10.6 or newer required";
+ error "Mac OS X 10.9 or newer required";
 #endif
 #endif
 		    ])],
-		    ns_osx_have_106=yes,
-		    ns_osx_have_106=no)
-    AC_MSG_RESULT([$ns_osx_have_106])
+		    ns_osx_have_109=yes,
+		    ns_osx_have_109=no)
+    AC_MSG_RESULT([$ns_osx_have_109])
 
-    if test $ns_osx_have_106 = no; then
-       AC_MSG_ERROR([Mac OS X 10.6 or newer is required]);
+    if test $ns_osx_have_109 = no; then
+       AC_MSG_ERROR([Mac OS X 10.9 or newer is required]);
     fi
   fi
 fi

--- a/src/nsfns.m
+++ b/src/nsfns.m
@@ -1921,10 +1921,8 @@ DEFUN ("ns-popup-font-panel", Fns_popup_font_panel, Sns_popup_font_panel,
 	    {
 	      if (EQ (face->font->driver->type, Qns))
 		nsfont = ((struct nsfont_info *)face->font)->nsfont;
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5
 	      else
 		nsfont = (NSFont *) macfont_get_nsctfont (face->font);
-#endif
 	    }
 	}
     } 
@@ -3582,9 +3580,6 @@ ns_screen_name (CGDirectDisplayID did)
 {
   char *name = NULL;
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
-  if (floor(NSAppKitVersionNumber) >= 1265) // NSAppKitVersionNumber10_9
-{
   mach_port_t masterPort;
   io_iterator_t it;
   io_object_t obj;
@@ -3621,12 +3616,6 @@ ns_screen_name (CGDirectDisplayID did)
     }
 
   IOObjectRelease (it);
- }
-else
-#endif
-  {
-  name = ns_get_name_from_ioreg (CGDisplayIOServicePort (did));
-  }
   return name;
 }
 
@@ -3864,16 +3853,10 @@ compute_tip_xy (struct frame *f,
       pt.y = dpyinfo->last_mouse_motion_y;
       /* Convert to screen coordinates */
       pt = [view convertPoint: pt toView: nil];
-     if (! [NSWindow respondsToSelector: @selector(convertRectToScreen:)])
-      pt = [[view window] convertBaseToScreen: pt];
-     else
-      {
         NSRect r = NSMakeRect (pt.x, pt.y, 0, 0);
         r = [[view window] convertRectToScreen: r];
         pt.x = r.origin.x;
         pt.y = r.origin.y;
-      }
-#endif
     }
   else
     {
@@ -4429,3 +4412,5 @@ be used as the image of the icon representing the frame.  */);
   as_status = 0;
   as_result = 0;
 }
+
+#endif /* HAVE_NS */

--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -9127,17 +9127,8 @@ not_in_argv (NSString *arg)
 {
   /* TODO: if we want to allow variable widths, this is the place to do it,
            however neither GNUstep nor Cocoa support it very well */
-  CGFloat r;
-  if (! [NSScroller respondsToSelector:@selector(scrollerWidthForControlSize:scrollerStyle:)])
-    {
-  r = [NSScroller scrollerWidth];
-    }
-  else
-    {
-  r = [NSScroller scrollerWidthForControlSize: NSRegularControlSize
-                                scrollerStyle: NSScrollerStyleLegacy];
-    }
-  return r;
+  return [NSScroller scrollerWidthForControlSize: NSRegularControlSize
+                                   scrollerStyle: NSScrollerStyleLegacy];
 }
 
 

--- a/src/nsterm.m
+++ b/src/nsterm.m
@@ -5775,6 +5775,16 @@ typedef struct _AppleEventSelectionRange {
   return YES;
 }
 
+#ifdef EXPERIMENTAL_XCODE_ODB_SUPPORT
+/* Hayo Baan: Please note that below experimental code makes use of
+   deprecated functions.
+
+   Instead of FSRef* the code should be updated to make use of NSURL.
+
+   FSGetCatalogInfo seems to have been a no-op function for a very
+   long time now so I'm unsure if this code has ever been working.
+ */
+
 /* Make FSSpec from NSString
    based on http://www.opensource.apple.com/darwinsource/10.3/Kerberos-47/KerberosFramework/Common/Sources/FSpUtils.c */
 - (OSErr)getFSRefAtPath:(NSString*)sourceItem ref:(FSRef*)sourceRef
@@ -5821,7 +5831,6 @@ typedef struct
   short saved; // set this to zero when replying
 } ModificationInfo;
 
-#ifdef EXPERIMENTAL_XCODE_ODB_SUPPORT
 - (void)handleXcodeModEvent:(NSAppleEventDescriptor *)event withReplyEvent: (NSAppleEventDescriptor *)replyEvent
 {
   Lisp_Object tail, buf, file;
@@ -5882,7 +5891,7 @@ typedef struct
   [replyEvent setParamDescriptor:replyDesc forKeyword:keyDirectObject];
   // NSLog(@"reply: %@\n", replyEvent);
 }
-#endif
+#endif /* EXPERIMENTAL_XCODE_ODB_SUPPORT */
 
 /* **************************************************************************
 


### PR DESCRIPTION
Updated the build script to require 10.9+ for the build.

Removed/replaced deprecated functions.

Fixed wrongly placed #endif in nsfns.m